### PR TITLE
Map MIDI channels to Arduino pins on a first-come-first-served basis.

### DIFF
--- a/Java/MoppyDesk/src/moppydesk/MoppySequencer.java
+++ b/Java/MoppyDesk/src/moppydesk/MoppySequencer.java
@@ -33,8 +33,6 @@ public class MoppySequencer implements MetaEventListener{
         mb = new MoppyBridge(comPort); //Create MoppyBridge on the COM port with the Arduino
         mp = new MoppyPlayer(mb);
 
-        mb.resetDrives();
-
         sequencer = MidiSystem.getSequencer(false);
         sequencer.open();
         sequencer.getTransmitter().setReceiver(mp); // Set MoppyPlayer as a receiver.
@@ -42,8 +40,9 @@ public class MoppySequencer implements MetaEventListener{
     }
 
     public void loadFile(String filePath) throws InvalidMidiDataException, IOException, MidiUnavailableException {
-
         sequencer.stop();
+        mp.reset();
+        
         Sequence sequence = MidiSystem.getSequence(new File(filePath));
         
         sequencer.setSequence(sequence);
@@ -56,9 +55,9 @@ public class MoppySequencer implements MetaEventListener{
     
     public void stopSequencer(){
         if (sequencer.isOpen()){
-                sequencer.stop();
-            }
-        mb.resetDrives();
+            sequencer.stop();
+        }
+        mp.reset();
     }
     
     public void setTempo(float newTempo){


### PR DESCRIPTION
Helps avoid missing parts in the situation where fewer than 16 floppy drives have been connected, and MIDI channels have not been assigned sequentially starting from 1.

I'm aware that MoppyAdvanced already has mapping strategies, but I found the mapping to be buggy (the strategy I wanted kept messing up lots of notes) and eventually found that this simple but dumb solution worked the best for me.

The reason why I am mapping pins on-the-fly during playback is because the Track class does not appear to be able to reveal its internal MIDI channel number. I can see you are retrieving the channel number through the MidiMessage.getStatus() function, which is also a bit of a hack.

If you can think of a more elegant way to do this, by all means suggest it. But then you've got to write it. :-)
