### PR TITLE
Enhanced Realtime Playability

### DIFF
--- a/Java/MoppyDesk/src/moppydesk/outputs/LegatoManager.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/LegatoManager.java
@@ -1,0 +1,30 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package moppydesk.outputs;
+
+public class LegatoManager {
+    int currentNote = 0;
+    
+    void noteOn(int note) {
+        currentNote = note;
+        
+//        System.out.println("Note turned on: " + note);
+//        System.out.println("Current note: " + currentNote);
+    }
+    
+    boolean noteOff(int note) {
+        if(note == currentNote) {
+            currentNote = 0;
+            
+//          System.out.println("Note turned off: " + note);
+//          System.out.println("Current note: " + currentNote);
+            
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Hello everybody,

This is my first time on Github and using Java and Netbeans, so I apologize beforehand for anything I did wrong or misunderstood. Also I don't know if there already was a fork implementing this feature.

Initially it was very difficult to play legato notes, because a NoteOff signal stopped all the notes when a key was released, even if another note was still running. With this addition a stop signal is only sent when the FDD should actually be silent. It makes playing with a keyboard in real time a LOT easier. It now plays the same as a single voice synthesizer, like for instance a lead synth.

I have tested it with my MIDI-keyboard and a single FDD connected to my Arduino. I hope I did everything correctly and if so, I would strongly recommend to implement this in the main build, because for a musician like me, it turns the real-time input from hardly to perfectly playable. I hope you like it

Sincerely,
Rev707
