### PR TITLE
Issue 86 fix

### DIFF
--- a/Java/MoppyDesk/src/moppydesk/Constants.java
+++ b/Java/MoppyDesk/src/moppydesk/Constants.java
@@ -7,6 +7,7 @@ package moppydesk;
 public class Constants {
         public static final String PREF_LOADED_SEQ = "loadedSequencePath";
         public static final String PREF_OUTPUT_SETTINGS = "outputSettingsArray";
+        public static final String PREF_AUTORESET = "autoReset";
         
         public static final String PREF_POOL_ENABLE = "poolingEnabled";
         public static final String PREF_POOL_FROM_START = "poolingFromStart";

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyCOMBridge.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyCOMBridge.java
@@ -67,7 +67,7 @@ public class MoppyCOMBridge {
     /**
      * Sends a '0' period to all drives to silence them.
      */
-    private void silenceDrives() {
+    public void silenceDrives() {
         // Stop notes
         for (int d = FIRST_PIN; d <= MAX_PIN; d += 2) {
             sendArray(new byte[]{(byte) d, (byte) 0, (byte) 0});

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyPlayerOutput.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyPlayerOutput.java
@@ -44,6 +44,10 @@ public class MoppyPlayerOutput implements MoppyReceiver {
     
     MoppyCOMBridge mb;
     SerialPort com;
+    
+    public void silenceDrives() {
+    	mb.silenceDrives();
+    }
 
     public MoppyPlayerOutput(MoppyCOMBridge newMb) {
         mb = newMb;

--- a/Java/MoppyDesk/src/moppydesk/ui/MoppyControlWindow.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/MoppyControlWindow.java
@@ -11,14 +11,20 @@ import moppydesk.outputs.MoppyPlayerOutput;
 import gnu.io.NoSuchPortException;
 import gnu.io.PortInUseException;
 import gnu.io.UnsupportedCommOperationException;
+
 import java.awt.Component;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.sound.midi.MidiDevice.Info;
 import javax.sound.midi.MidiUnavailableException;
 import javax.swing.JOptionPane;
+
 import moppydesk.*;
 import moppydesk.outputs.MoppyReceiver;
 
@@ -263,6 +269,15 @@ public class MoppyControlWindow extends javax.swing.JFrame {
                     app.rm.setReceiver(ch, outputPlayers.get(os.midiDeviceName));
                 }
             }
+        }
+    }
+    
+    public void silenceDrives() {
+    	Iterator<Entry<String, MoppyReceiver>> it = outputPlayers.entrySet().iterator();
+        while (it.hasNext()) {
+            Entry<String, MoppyReceiver> val = (Entry<String, MoppyReceiver>)it.next();
+            MoppyPlayerOutput mpo = (MoppyPlayerOutput)val.getValue();
+            mpo.silenceDrives();
         }
     }
 

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.form
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.form
@@ -16,9 +16,9 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" attributes="0">
+              <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="sequenceNameLabel" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -40,12 +40,18 @@
                       <Component id="stopButton" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <Group type="102" alignment="1" attributes="0">
-                      <Component id="currentPositionLabel" min="-2" pref="30" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Group type="102" alignment="1" attributes="0">
+                              <Component id="currentPositionLabel" min="-2" pref="30" max="-2" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Component id="sequenceProgressSlider" min="-2" pref="376" max="-2" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Component id="totalPositionLabel" min="-2" pref="30" max="-2" attributes="0"/>
+                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                          </Group>
+                          <Component id="autoResetCB" alignment="1" max="32767" attributes="0"/>
+                      </Group>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="sequenceProgressSlider" min="-2" pref="376" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="totalPositionLabel" min="-2" pref="30" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
                   </Group>
               </Group>
           </Group>
@@ -53,7 +59,7 @@
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" alignment="1" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
@@ -77,7 +83,9 @@
                       </Group>
                   </Group>
               </Group>
-              <EmptySpace pref="33" max="32767" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Component id="autoResetCB" min="-2" pref="24" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
               <Group type="103" groupAlignment="0" max="-2" attributes="0">
                   <Component id="sequenceProgressSlider" max="32767" attributes="0"/>
                   <Component id="currentPositionLabel" alignment="0" max="32767" attributes="0"/>
@@ -161,6 +169,15 @@
       <Properties>
         <Property name="text" type="java.lang.String" value="00:00"/>
       </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="autoResetCB">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Auto-reset drives on stop"/>
+        <Property name="horizontalAlignment" type="int" value="0"/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="autoResetCBActionPerformed"/>
+      </Events>
     </Component>
   </SubComponents>
 </Form>

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -238,6 +238,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
             startButton.setText("Start");
             controlWindow.setStatus("Stopped.");
         } else {
+            seq.resetSequencer();
             app.rm.reset();
             controlWindow.setStatus("Reset.");
         }

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -54,6 +54,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         long currentSeconds = seq.getSecondsPosition();
         long totalSeconds = seq.getSecondsLength();
         if ((!seq.isRunning()) && (currentSeconds == totalSeconds)) {
+        	currentSeconds = 0;
         	seq.setSecondsPosition(0);
         }
         sequenceProgressSlider.setValue((int) (currentSeconds));

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -55,7 +55,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         long totalSeconds = seq.getSecondsLength();
         if ((!seq.isRunning()) && (currentSeconds == totalSeconds)) {
         	currentSeconds = 0;
-        	seq.setSecondsPosition(0);
+        	seq.resetSequencer();
         }
         sequenceProgressSlider.setValue((int) (currentSeconds));
         String currentPosition = String.format("%d:%02d",

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -52,12 +52,16 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
 
     private void updateProgressDisplay() {
         long currentSeconds = seq.getSecondsPosition();
+        long totalSeconds = seq.getSecondsLength();
+        if ((!seq.isRunning()) && (currentSeconds == totalSeconds)) {
+        	seq.setSecondsPosition(0);
+        }
         sequenceProgressSlider.setValue((int) (currentSeconds));
         String currentPosition = String.format("%d:%02d",
                 TimeUnit.SECONDS.toMinutes(currentSeconds),
                 currentSeconds % 60);
         String totalPosition = String.format("%d:%02d",
-                TimeUnit.SECONDS.toMinutes(seq.getSecondsLength()),
+                TimeUnit.SECONDS.toMinutes(totalSeconds),
                 seq.getSecondsLength() % 60);
         currentPositionLabel.setText(currentPosition);
         totalPositionLabel.setText(totalPosition);

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -41,6 +41,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         this.controlWindow = mcw;
 
         initComponents();
+        autoResetCB.setSelected(app.prefs.getBoolean(Constants.PREF_AUTORESET, false));
 
         progressTimer = new Timer(1000, new ActionListener() {
 
@@ -56,6 +57,10 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         if ((!seq.isRunning()) && (currentSeconds == totalSeconds)) {
         	currentSeconds = 0;
         	seq.resetSequencer();
+                if (autoResetCB.isSelected())
+                {
+                    app.rm.reset();
+                }
         }
         sequenceProgressSlider.setValue((int) (currentSeconds));
         String currentPosition = String.format("%d:%02d",
@@ -87,6 +92,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         sequenceProgressSlider = new javax.swing.JSlider();
         currentPositionLabel = new javax.swing.JLabel();
         totalPositionLabel = new javax.swing.JLabel();
+        autoResetCB = new javax.swing.JCheckBox();
 
         jLabel1.setText("Current Sequence:");
 
@@ -144,40 +150,52 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
 
         totalPositionLabel.setText("00:00");
 
+        autoResetCB.setText("Auto-reset drives on stop");
+        autoResetCB.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
+        autoResetCB.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                autoResetCBActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(sequenceNameLabel)
                             .addComponent(jLabel1))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addComponent(loadButton))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                    .addGroup(layout.createSequentialGroup()
                         .addGap(126, 126, 126)
                         .addComponent(bpmLabel)
                         .addGap(0, 0, Short.MAX_VALUE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                    .addGroup(layout.createSequentialGroup()
                         .addComponent(jSlider1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addGap(18, 18, 18)
                         .addComponent(startButton, javax.swing.GroupLayout.PREFERRED_SIZE, 76, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(stopButton))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addComponent(currentPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(sequenceProgressSlider, javax.swing.GroupLayout.PREFERRED_SIZE, 376, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(totalPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                                .addComponent(currentPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(sequenceProgressSlider, javax.swing.GroupLayout.PREFERRED_SIZE, 376, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(totalPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(0, 0, Short.MAX_VALUE))
+                            .addComponent(autoResetCB, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                         .addContainerGap())))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
@@ -195,7 +213,9 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                             .addComponent(stopButton)
                             .addComponent(startButton))))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 33, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(autoResetCB, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                     .addComponent(sequenceProgressSlider, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(currentPositionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
@@ -235,6 +255,10 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
             controlWindow.setStatus("Stopping...");
             seq.stopSequencer();
             seq.resetSequencer();
+            if (autoResetCB.isSelected())
+            {
+                app.rm.reset();
+            }
             startButton.setText("Start");
             controlWindow.setStatus("Stopped.");
         } else {
@@ -270,6 +294,10 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
                 seconds % 60));
     }//GEN-LAST:event_sequenceProgressDragged
 
+    private void autoResetCBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_autoResetCBActionPerformed
+        app.prefs.putBoolean(Constants.PREF_AUTORESET, autoResetCB.isSelected());
+    }//GEN-LAST:event_autoResetCBActionPerformed
+
     public void tempoChanged(int newTempo) {
         jSlider1.setValue(newTempo);
         bpmLabel.setText(newTempo + " bpm");
@@ -295,6 +323,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         }
     }
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JCheckBox autoResetCB;
     private javax.swing.JLabel bpmLabel;
     private javax.swing.JLabel currentPositionLabel;
     private javax.swing.JLabel jLabel1;

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -57,10 +57,11 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         if ((!seq.isRunning()) && (currentSeconds == totalSeconds)) {
         	currentSeconds = 0;
         	seq.resetSequencer();
-                if (autoResetCB.isSelected())
-                {
-                    app.rm.reset();
-                }
+            controlWindow.silenceDrives();
+            if (autoResetCB.isSelected())
+            {
+                app.rm.reset();
+            }
         }
         sequenceProgressSlider.setValue((int) (currentSeconds));
         String currentPosition = String.format("%d:%02d",
@@ -246,6 +247,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
 
     private void pauseSequencer() {
         seq.stopSequencer();
+        controlWindow.silenceDrives();
         startButton.setText("Start");
         controlWindow.setStatus("...Paused");
     }
@@ -255,6 +257,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
             controlWindow.setStatus("Stopping...");
             seq.stopSequencer();
             seq.resetSequencer();
+            controlWindow.silenceDrives();
             if (autoResetCB.isSelected())
             {
                 app.rm.reset();

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -29,6 +29,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
     MoppyUI app;
     final JFileChooser sequenceChooser = new JFileChooser();
     Timer progressTimer;
+    Timer onStopTimer;
     private boolean isConnected = false;
     private boolean fileLoaded = false;
 
@@ -49,9 +50,16 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
                 updateProgressDisplay();
             }
         });
+        
+        onStopTimer = new Timer(50, new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+                onSequencerStop();
+            }
+        });
     }
 
-    private void updateProgressDisplay() {
+    private void onSequencerStop() {
         long currentSeconds = seq.getSecondsPosition();
         long totalSeconds = seq.getSecondsLength();
         if ((!seq.isRunning()) && (currentSeconds == totalSeconds)) {
@@ -63,6 +71,11 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
                 app.rm.reset();
             }
         }
+    }
+    
+    private void updateProgressDisplay() {
+        long currentSeconds = seq.getSecondsPosition();
+        long totalSeconds = seq.getSecondsLength();
         sequenceProgressSlider.setValue((int) (currentSeconds));
         String currentPosition = String.format("%d:%02d",
                 TimeUnit.SECONDS.toMinutes(currentSeconds),
@@ -345,6 +358,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
 
     public void connected() {
         progressTimer.start();
+        onStopTimer.start();
         isConnected = true;
         if (fileLoaded) {
             startButton.setEnabled(true);
@@ -356,6 +370,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         pauseSequencer();
         isConnected = false;
         progressTimer.stop();
+        onStopTimer.stop();
         seq.setReceiver(null); //Clear receiver so there's no connection here.
     }
 }


### PR DESCRIPTION
Implemented all suggestions from issue 86:

1.1) Added auto-reset checkbox. Now drives could be reset automatically when song is stopped.
1.2) Note-off is now forced for all drives on stop, pause and song end, which should prevent stuck-note problem from ever happening even with drive pooling.
2) When song ends, position slider is automatically reset to beginning.
3) Clicking reset button second time will now actually reset song to the beginning.

Those changes improve Moppy's usability, particularly drive-pooling feature.
