### PR TITLE
Various Improvements 1

### DIFF
--- a/Java/MoppyDesk/nbproject/project.xml
+++ b/Java/MoppyDesk/nbproject/project.xml
@@ -11,5 +11,8 @@
                 <root id="test.src.dir"/>
             </test-roots>
         </data>
+        <spellchecker-wordlist xmlns="http://www.netbeans.org/ns/spellchecker-wordlist/1">
+            <word>Arduino</word>
+        </spellchecker-wordlist>
     </configuration>
 </project>

--- a/Java/MoppyDesk/src/moppydesk/Constants.java
+++ b/Java/MoppyDesk/src/moppydesk/Constants.java
@@ -6,6 +6,9 @@ package moppydesk;
  */
 public class Constants {
         public static final String PREF_LOADED_SEQ = "loadedSequencePath";
+        public static final String PREF_DELAY_RESET = "delayResetValue";
+        public static final String PREF_RESET_DRIVES = "resetDrivesValue";
+        public static final String PREF_REPEAT_SEQ = "repeatSequenceValue";
         public static final String PREF_OUTPUT_SETTINGS = "outputSettingsArray";
         
         public static final String PREF_POOL_ENABLE = "poolingEnabled";

--- a/Java/MoppyDesk/src/moppydesk/MoppyStatusConsumer.java
+++ b/Java/MoppyDesk/src/moppydesk/MoppyStatusConsumer.java
@@ -10,4 +10,5 @@ package moppydesk;
  */
 public interface MoppyStatusConsumer {
     public void tempoChanged(int newTempo);
+    public void SequenceEnded();
 }

--- a/Java/MoppyDesk/src/moppydesk/inputs/MoppySequencer.java
+++ b/Java/MoppyDesk/src/moppydesk/inputs/MoppySequencer.java
@@ -1,8 +1,5 @@
 package moppydesk.inputs;
 
-import gnu.io.NoSuchPortException;
-import gnu.io.PortInUseException;
-import gnu.io.UnsupportedCommOperationException;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -112,6 +109,13 @@ public class MoppySequencer implements MetaEventListener, Transmitter{
             }
             
             System.out.println("Tempo changed to: " + newTempo);
+        }
+        else if (meta.getType() == 47) {
+            //MrSolidSnake745: Exposing end of sequence event
+            for (MoppyStatusConsumer c : listeners) {
+                c.SequenceEnded();
+            }            
+            System.out.println("End of current sequence");
         }
     }
 

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyCOMBridge.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyCOMBridge.java
@@ -67,7 +67,7 @@ public class MoppyCOMBridge {
     /**
      * Sends a '0' period to all drives to silence them.
      */
-    private void silenceDrives() {
+    public void silenceDrives() {
         // Stop notes
         for (int d = FIRST_PIN; d <= MAX_PIN; d += 2) {
             sendArray(new byte[]{(byte) d, (byte) 0, (byte) 0});

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyMIDIOutput.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyMIDIOutput.java
@@ -73,4 +73,8 @@ public class MoppyMIDIOutput implements MoppyReceiver{
             }
         }
     }
+
+    //MrSolidSnake745: A system reset should suffice
+    //If not, sending a different message would probably work
+    public void silence() { reset(); }
 }

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyPlayerOutput.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyPlayerOutput.java
@@ -2,7 +2,6 @@ package moppydesk.outputs;
 
 import gnu.io.SerialPort;
 import javax.sound.midi.MidiMessage;
-import javax.sound.midi.Receiver;
 
 /**
  *
@@ -17,7 +16,7 @@ public class MoppyPlayerOutput implements MoppyReceiver {
      * clock-cycles in the micro() function, and because milliseconds aren't
      * precise enough for musical notes.
      * 
-     * Notes are named (e.g. C1-B4) based on scientfic pitch notation (A4=440Hz) 
+     * Notes are named (e.g. C1-B4) based on scientific pitch notation (A4=440Hz) 
      */
     public static int[] microPeriods = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -109,5 +108,9 @@ public class MoppyPlayerOutput implements MoppyReceiver {
 
     public void reset() {
         mb.resetDrives();
+    }
+
+    public void silence() {
+        mb.silenceDrives();
     }
 }

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyReceiver.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyReceiver.java
@@ -13,4 +13,5 @@ public interface MoppyReceiver extends Receiver{
      * This should not disconnect or dispose of any connection though.
      */
     public void reset();
+    public void silence();
 }

--- a/Java/MoppyDesk/src/moppydesk/outputs/ReceiverMarshaller.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/ReceiverMarshaller.java
@@ -65,7 +65,7 @@ public class ReceiverMarshaller implements MoppyReceiver{
     /**
      * Explicity closes all output receivers, and nulls the array.
      * This differs slightly from the use described in {@link MidiDevice} in that
-     * the ReceiverMarshaller itself is not neccesarily closed when this is called.
+     * the ReceiverMarshaller itself is not necessarily closed when this is called.
      * After being closed, new receivers can continue to be added to the ReceiverMarshaller.
      */
     public void close() {
@@ -79,7 +79,7 @@ public class ReceiverMarshaller implements MoppyReceiver{
 
     /**
      * Finds the unique set of receivers and calls the {@link MoppyReceiver#reset() } method.
-     * We go through the trouble of finding uniques incase the reset is time-consuming.
+     * We go through the trouble of finding unique receivers incase the reset is time-consuming.
      */
     public void reset() {
         ArrayList<MoppyReceiver> uniqueReceivers = new ArrayList<MoppyReceiver>();
@@ -90,6 +90,18 @@ public class ReceiverMarshaller implements MoppyReceiver{
         }
         for (MoppyReceiver r : uniqueReceivers){
             r.reset();
+        }
+    }
+
+    public void silence() {
+        ArrayList<MoppyReceiver> uniqueReceivers = new ArrayList<MoppyReceiver>();
+        for (MoppyReceiver r: outputReceivers){
+            if (r!= null && !uniqueReceivers.contains(r)){
+                uniqueReceivers.add(r);
+            }
+        }
+        for (MoppyReceiver r : uniqueReceivers){
+            r.silence();
         }
     }
 }

--- a/Java/MoppyDesk/src/moppydesk/ui/ChannelOutControl.form
+++ b/Java/MoppyDesk/src/moppydesk/ui/ChannelOutControl.form
@@ -90,6 +90,7 @@
         </Property>
       </Properties>
       <Events>
+        <EventHandler event="popupMenuWillBecomeVisible" listener="javax.swing.event.PopupMenuListener" parameters="javax.swing.event.PopupMenuEvent" handler="comComboBoxPopupMenuWillBecomeVisible"/>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comComboBoxActionPerformed"/>
       </Events>
     </Component>

--- a/Java/MoppyDesk/src/moppydesk/ui/ChannelOutControl.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/ChannelOutControl.java
@@ -8,8 +8,6 @@ import java.awt.event.ActionEvent;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
-import javax.swing.JRadioButton;
-import moppydesk.outputs.MoppyCOMBridge;
 import moppydesk.OutputSetting;
 import moppydesk.OutputSetting.OutputType;
 
@@ -28,12 +26,11 @@ public class ChannelOutControl extends javax.swing.JPanel {
     public ChannelOutControl(MoppyControlWindow mcw, OutputSetting os) {
         this.settings = os;
         this.controlWindow = mcw;
-        initComponents();
+        initComponents();        
         loadSettings();
     }
 
     private void loadSettings() {
-
         if (settings.enabled) {
             enabledCB.setSelected(true);
             enableControls();
@@ -42,17 +39,21 @@ public class ChannelOutControl extends javax.swing.JPanel {
             disableControls();
         }
 
-
         if (settings.type.equals(OutputType.MOPPY)) {
             moppyTypeRB.setSelected(true);
             outputTypeChanged(OutputType.MOPPY);
         } else {
             MIDITypeRB.setSelected(true);
             outputTypeChanged(OutputType.MIDI);
-        }
-
-        comComboBox.setSelectedItem(settings.comPort);
-        midiOutComboBox.setSelectedItem(settings.midiDeviceName);
+        }        
+                    
+        //MrSolidSnake745: Ensure the saved settings are still valid and load their values
+        //Else default to the first item in the collection
+        if(doesCOMExist(settings.comPort)) {comComboBox.setSelectedItem(settings.comPort);}  
+        else {settings.comPort = (String) comComboBox.getModel().getElementAt(0);}
+                
+        if(doesMIDIExist(settings.midiDeviceName)) {midiOutComboBox.setSelectedItem(settings.midiDeviceName);}  
+        else {settings.midiDeviceName = (String) midiOutComboBox.getModel().getElementAt(0);}
     }
 
     public void lockControl(){
@@ -79,10 +80,24 @@ public class ChannelOutControl extends javax.swing.JPanel {
             outputTypeChanged(new ActionEvent(moppyTypeRB, ActionEvent.ACTION_PERFORMED, moppyTypeRB.getActionCommand()));
         } else if (MIDITypeRB.isSelected()){
             outputTypeChanged(new ActionEvent(MIDITypeRB, ActionEvent.ACTION_PERFORMED, MIDITypeRB.getActionCommand()));
-        }
-        
+        }        
     }
 
+    private boolean doesCOMExist(Object obj) {
+        return (((DefaultComboBoxModel)(comComboBox.getModel())).getIndexOf(obj) > -1);
+    }
+    
+    private boolean doesMIDIExist(Object obj) {
+        return (((DefaultComboBoxModel)(midiOutComboBox.getModel())).getIndexOf(obj) > -1);
+    }
+    
+    //MrSolidSnake745: Method to refresh the list of available COM ports
+    private void refreshAvailablePorts() {
+        comComboBox.setModel(new DefaultComboBoxModel(moppydesk.outputs.MoppyCOMBridge.getAvailableCOMPorts()));
+        if(doesCOMExist(settings.comPort)) {comComboBox.setSelectedItem(settings.comPort);} //To avoid losing last user selected value
+        else {settings.comPort = (String) comComboBox.getModel().getElementAt(0);}  //ActionPerformed event isn't triggered so we need to manually set
+    }
+    
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always
@@ -121,6 +136,15 @@ public class ChannelOutControl extends javax.swing.JPanel {
         });
 
         comComboBox.setModel(new DefaultComboBoxModel(moppydesk.outputs.MoppyCOMBridge.getAvailableCOMPorts()));
+        comComboBox.addPopupMenuListener(new javax.swing.event.PopupMenuListener() {
+            public void popupMenuCanceled(javax.swing.event.PopupMenuEvent evt) {
+            }
+            public void popupMenuWillBecomeInvisible(javax.swing.event.PopupMenuEvent evt) {
+            }
+            public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent evt) {
+                comComboBoxPopupMenuWillBecomeVisible(evt);
+            }
+        });
         comComboBox.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 comComboBoxActionPerformed(evt);
@@ -179,6 +203,7 @@ public class ChannelOutControl extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     private void comComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_comComboBoxActionPerformed
+        //MrSolidSnake745: FYI, this fires on initial click to generate dropdown and once more on clicking a value
         settings.comPort = (String) ((JComboBox) evt.getSource()).getSelectedItem();
     }//GEN-LAST:event_comComboBoxActionPerformed
 
@@ -215,6 +240,11 @@ public class ChannelOutControl extends javax.swing.JPanel {
             outputTypeChanged(OutputType.MIDI);
         }
     }//GEN-LAST:event_outputTypeChanged
+
+    private void comComboBoxPopupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent evt) {//GEN-FIRST:event_comComboBoxPopupMenuWillBecomeVisible
+        refreshAvailablePorts();
+    }//GEN-LAST:event_comComboBoxPopupMenuWillBecomeVisible
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JRadioButton MIDITypeRB;
     private javax.swing.JComboBox comComboBox;

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.form
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.form
@@ -88,10 +88,8 @@
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="RepeatCB" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="ResetDrivesCB" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Group type="103" alignment="3" groupAlignment="3" attributes="0">
-                      <Component id="DelayResetSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
+                  <Component id="DelayResetSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.form
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.3" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+<Form version="1.5" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -16,72 +16,88 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" attributes="0">
+              <EmptySpace min="10" pref="10" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                  <Component id="sequenceNameLabel" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace min="258" pref="258" max="-2" attributes="0"/>
+              <Component id="loadButton" min="-2" max="-2" attributes="0"/>
+          </Group>
+          <Group type="102" attributes="0">
+              <EmptySpace min="136" pref="136" max="-2" attributes="0"/>
+              <Component id="bpmLabel" min="-2" max="-2" attributes="0"/>
+          </Group>
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="1" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="sequenceNameLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="32767" attributes="0"/>
-                      <Component id="loadButton" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="126" max="-2" attributes="0"/>
-                      <Component id="bpmLabel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="jSlider1" max="32767" attributes="0"/>
-                      <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="startButton" min="-2" pref="76" max="-2" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="stopButton" min="-2" max="-2" attributes="0"/>
+                      <Component id="DelayResetSpinner" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <Component id="ResetDrivesCB" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="RepeatCB" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Group type="102" alignment="1" attributes="0">
+                  <Group type="102" attributes="0">
                       <Component id="currentPositionLabel" min="-2" pref="30" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <EmptySpace min="4" pref="4" max="-2" attributes="0"/>
                       <Component id="sequenceProgressSlider" min="-2" pref="376" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <EmptySpace min="4" pref="4" max="-2" attributes="0"/>
                       <Component id="totalPositionLabel" min="-2" pref="30" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
                   </Group>
               </Group>
+          </Group>
+          <Group type="102" alignment="0" attributes="0">
+              <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
+              <Component id="jSlider1" min="-2" pref="267" max="-2" attributes="0"/>
+              <EmptySpace min="18" pref="18" max="-2" attributes="0"/>
+              <Component id="startButton" min="-2" pref="76" max="-2" attributes="0"/>
+              <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
+              <Component id="stopButton" min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
+          <Group type="102" attributes="0">
+              <EmptySpace min="11" pref="11" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
+                  <Group type="102" attributes="0">
                       <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
                       <Component id="sequenceNameLabel" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Component id="loadButton" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="loadButton" min="-2" max="-2" attributes="0"/>
               </Group>
-              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+              <Component id="bpmLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="12" pref="12" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jSlider1" min="-2" max="-2" attributes="0"/>
                   <Group type="102" attributes="0">
-                      <Component id="bpmLabel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
-                      <Component id="jSlider1" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" attributes="0">
-                      <EmptySpace min="-2" pref="34" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="stopButton" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="startButton" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="8" pref="8" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="startButton" min="-2" max="-2" attributes="0"/>
+                          <Component id="stopButton" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
-              <EmptySpace pref="33" max="32767" attributes="0"/>
-              <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                  <Component id="sequenceProgressSlider" max="32767" attributes="0"/>
-                  <Component id="currentPositionLabel" alignment="0" max="32767" attributes="0"/>
-                  <Component id="totalPositionLabel" alignment="0" max="32767" attributes="0"/>
+              <EmptySpace min="-2" pref="8" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="RepeatCB" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="ResetDrivesCB" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Group type="103" alignment="3" groupAlignment="3" attributes="0">
+                      <Component id="DelayResetSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="currentPositionLabel" min="-2" pref="23" max="-2" attributes="0"/>
+                  <Component id="sequenceProgressSlider" min="-2" max="-2" attributes="0"/>
+                  <Component id="totalPositionLabel" min="-2" pref="23" max="-2" attributes="0"/>
               </Group>
           </Group>
       </Group>
@@ -160,6 +176,34 @@
     <Component class="javax.swing.JLabel" name="totalPositionLabel">
       <Properties>
         <Property name="text" type="java.lang.String" value="00:00"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="RepeatCB">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Repeat"/>
+        <Property name="toolTipText" type="java.lang.String" value="Repeats the song when selected."/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="ResetDrivesCB">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Reset Drives"/>
+        <Property name="toolTipText" type="java.lang.String" value="Resets the drives after the end of the current song."/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="ResetDrivesCBActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JSpinner" name="DelayResetSpinner">
+      <Properties>
+        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
+          <SpinnerModel initial="0" maximum="600" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
+        </Property>
+        <Property name="toolTipText" type="java.lang.String" value="Delays resetting the drives after the song ends by a number of seconds."/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel2">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Delay Reset:"/>
       </Properties>
     </Component>
   </SubComponents>

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -236,9 +236,8 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(RepeatCB)
                     .addComponent(ResetDrivesCB)
-                    .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                        .addComponent(DelayResetSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addComponent(jLabel2)))
+                    .addComponent(DelayResetSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel2))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(currentPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -382,7 +381,8 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
     //MrSolidSnake745: Simple use for the SequenceEnded event
     //Resets the sequence and drives if ResetDrivesCB is selected once the song has finished    
     public void SequenceEnded() {  
-        controlWindow.setStatus("Song has ended.");        
+        controlWindow.setStatus("Song has ended.");       
+        app.rm.silence(); //In case there are any stuck notes, most likely from pooling, silence all receivers
         seq.resetSequencer();        
         startButton.setText("Start");
         if(ResetDrivesCB.isSelected()) {

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -282,7 +282,8 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
             controlWindow.setStatus("Stopped.");
         } else {
             app.rm.reset();
-            controlWindow.setStatus("Reset.");
+            seq.resetSequencer();
+            controlWindow.setStatus("Reset.");            
         }
     }
 

--- a/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/SequencerControls.java
@@ -4,6 +4,7 @@
  */
 package moppydesk.ui;
 
+import java.awt.Component;
 import moppydesk.inputs.MoppySequencer;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -41,15 +42,29 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         this.controlWindow = mcw;
 
         initComponents();
-
+        loadPreferences();
+        
         progressTimer = new Timer(1000, new ActionListener() {
 
             public void actionPerformed(ActionEvent e) {
                 updateProgressDisplay();
             }
-        });
+        });       
     }
 
+    private void loadPreferences() {
+        ResetDrivesCB.setSelected(app.prefs.getBoolean(Constants.PREF_RESET_DRIVES, false));
+        RepeatCB.setSelected(app.prefs.getBoolean(Constants.PREF_REPEAT_SEQ, false));
+        DelayResetSpinner.setValue(app.prefs.getInt(Constants.PREF_DELAY_RESET, 0));
+        DelayResetSpinner.setEnabled(ResetDrivesCB.isSelected());
+    }
+    
+    private void savePreferences() {
+        app.prefs.putBoolean(Constants.PREF_RESET_DRIVES, ResetDrivesCB.isSelected());
+        app.prefs.putBoolean(Constants.PREF_REPEAT_SEQ, RepeatCB.isSelected());
+        app.prefs.putInt(Constants.PREF_DELAY_RESET, (Integer)DelayResetSpinner.getValue());                
+    }
+    
     private void updateProgressDisplay() {
         long currentSeconds = seq.getSecondsPosition();
         sequenceProgressSlider.setValue((int) (currentSeconds));
@@ -82,6 +97,10 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         sequenceProgressSlider = new javax.swing.JSlider();
         currentPositionLabel = new javax.swing.JLabel();
         totalPositionLabel = new javax.swing.JLabel();
+        RepeatCB = new javax.swing.JCheckBox();
+        ResetDrivesCB = new javax.swing.JCheckBox();
+        DelayResetSpinner = new javax.swing.JSpinner();
+        jLabel2 = new javax.swing.JLabel();
 
         jLabel1.setText("Current Sequence:");
 
@@ -139,62 +158,92 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
 
         totalPositionLabel.setText("00:00");
 
+        RepeatCB.setText("Repeat");
+        RepeatCB.setToolTipText("Repeats the song when selected.");
+
+        ResetDrivesCB.setText("Reset Drives");
+        ResetDrivesCB.setToolTipText("Resets the drives after the end of the current song.");
+        ResetDrivesCB.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                ResetDrivesCBActionPerformed(evt);
+            }
+        });
+
+        DelayResetSpinner.setModel(new javax.swing.SpinnerNumberModel(0, 0, 600, 1));
+        DelayResetSpinner.setToolTipText("Delays resetting the drives after the song ends by a number of seconds.");
+
+        jLabel2.setText("Delay Reset:");
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
+                .addGap(10, 10, 10)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel1)
+                    .addComponent(sequenceNameLabel))
+                .addGap(258, 258, 258)
+                .addComponent(loadButton))
+            .addGroup(layout.createSequentialGroup()
+                .addGap(136, 136, 136)
+                .addComponent(bpmLabel))
+            .addGroup(layout.createSequentialGroup()
+                .addGap(10, 10, 10)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(sequenceNameLabel)
-                            .addComponent(jLabel1))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(loadButton))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addGap(126, 126, 126)
-                        .addComponent(bpmLabel)
-                        .addGap(0, 0, Short.MAX_VALUE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addComponent(jSlider1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addGap(18, 18, 18)
-                        .addComponent(startButton, javax.swing.GroupLayout.PREFERRED_SIZE, 76, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(jLabel2)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(stopButton))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                        .addComponent(DelayResetSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addComponent(ResetDrivesCB)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(RepeatCB))
+                    .addGroup(layout.createSequentialGroup()
                         .addComponent(currentPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGap(4, 4, 4)
                         .addComponent(sequenceProgressSlider, javax.swing.GroupLayout.PREFERRED_SIZE, 376, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(totalPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addContainerGap())))
+                        .addGap(4, 4, 4)
+                        .addComponent(totalPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE))))
+            .addGroup(layout.createSequentialGroup()
+                .addGap(10, 10, 10)
+                .addComponent(jSlider1, javax.swing.GroupLayout.PREFERRED_SIZE, 267, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(18, 18, 18)
+                .addComponent(startButton, javax.swing.GroupLayout.PREFERRED_SIZE, 76, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(6, 6, 6)
+                .addComponent(stopButton))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
+                .addGap(11, 11, 11)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
                         .addComponent(jLabel1)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGap(6, 6, 6)
                         .addComponent(sequenceNameLabel))
                     .addComponent(loadButton))
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                .addComponent(bpmLabel)
+                .addGap(12, 12, 12)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jSlider1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addGroup(layout.createSequentialGroup()
-                        .addComponent(bpmLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(jSlider1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(34, 34, 34)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                            .addComponent(stopButton)
-                            .addComponent(startButton))))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 33, Short.MAX_VALUE)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                    .addComponent(sequenceProgressSlider, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(currentPositionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(totalPositionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                        .addGap(8, 8, 8)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(startButton)
+                            .addComponent(stopButton))))
+                .addGap(8, 8, 8)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(RepeatCB)
+                    .addComponent(ResetDrivesCB)
+                    .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(DelayResetSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(jLabel2)))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(currentPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(sequenceProgressSlider, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(totalPositionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE)))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -264,6 +313,10 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
                 seconds % 60));
     }//GEN-LAST:event_sequenceProgressDragged
 
+    private void ResetDrivesCBActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_ResetDrivesCBActionPerformed
+        DelayResetSpinner.setEnabled(ResetDrivesCB.isSelected());
+    }//GEN-LAST:event_ResetDrivesCBActionPerformed
+
     public void tempoChanged(int newTempo) {
         jSlider1.setValue(newTempo);
         bpmLabel.setText(newTempo + " bpm");
@@ -289,9 +342,13 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         }
     }
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JSpinner DelayResetSpinner;
+    private javax.swing.JCheckBox RepeatCB;
+    private javax.swing.JCheckBox ResetDrivesCB;
     private javax.swing.JLabel bpmLabel;
     private javax.swing.JLabel currentPositionLabel;
     private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JSlider jSlider1;
     private javax.swing.JButton loadButton;
     private javax.swing.JLabel sequenceNameLabel;
@@ -311,6 +368,7 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         if (fileLoaded) {
             startButton.setEnabled(true);
         }
+        savePreferences();
     }
 
     public void disconnected() {
@@ -319,5 +377,33 @@ public class SequencerControls extends InputPanel implements MoppyStatusConsumer
         isConnected = false;
         progressTimer.stop();
         seq.setReceiver(null); //Clear receiver so there's no connection here.
+    }
+
+    //MrSolidSnake745: Simple use for the SequenceEnded event
+    //Resets the sequence and drives if ResetDrivesCB is selected once the song has finished    
+    public void SequenceEnded() {  
+        controlWindow.setStatus("Song has ended.");        
+        seq.resetSequencer();        
+        startButton.setText("Start");
+        if(ResetDrivesCB.isSelected()) {
+            int y = ((Integer)DelayResetSpinner.getValue());
+            if(y > 0) {
+                try {
+                    setEnabledAllControls(false); //Don't want users messing with controls while we delay                
+                    controlWindow.setStatus("Waiting " + y + " seconds before reset...");
+                    Thread.sleep(y * 1000); //Thread is sooooo sleepy...
+                }
+                catch(Exception x){}
+                finally{setEnabledAllControls(true);}
+            }            
+            controlWindow.setStatus("Resetting!");
+            app.rm.reset();
+            controlWindow.setStatus("Reset.");
+        }
+        if(RepeatCB.isSelected()) { playSequencer(); }
+    }
+    
+    public void setEnabledAllControls(boolean value) {
+        for (Component c : this.getComponents()) {c.setEnabled(value);}
     }
 }


### PR DESCRIPTION
I've made a lot of changes to Moppy over the last couple years. I'm trying to merge some basic features/fixes I've implemented as well as help Sammy1Am out with reported issues. The changes were made as generic as possible so hopefully its beneficial for everyone.

This set of improvements focuses on Issue 86.
- Implemented an end of sequence event: Basically fires at the end of a song/sequence and allows you to do additional things. To demonstrate, I'm resetting the sequencer at the end of songs and implemented both an auto drive reset with optional delay and reset function. You can use this for so much more. In my own version of Moppy, I use it to implement playlist functionality or do certain actions to help when I'm recording for my channel.
- Exposed silenceDrives and implemented it for ReceiverMarshaller: Just made silence part of the MoppyReceiver interface so that the Marshaller can call it for every instance. Silencing all receivers at the end of a song in case there are any stuck notes from drive pooling.
- Added a sequencer reset when the sequencer is not playing: Pretty straight forward. Currently you cannot reset the sequencer once it stops playing. Now hitting reset while the sequencer is stopped will also reset the sequence along with the drives.
