### PR TITLE
Added in numerous events + related features

### DIFF
--- a/Java/MoppyDesk/src/moppydesk/MoppyUI.java
+++ b/Java/MoppyDesk/src/moppydesk/MoppyUI.java
@@ -27,6 +27,7 @@ import moppydesk.ui.MoppyControlWindow;
  */
 public class MoppyUI {
 
+    MoppyControlWindow mainWindow;
     //Input objects
     public MoppySequencer ms;
     public MoppyMIDIInput midiIn;
@@ -40,18 +41,28 @@ public class MoppyUI {
     protected void startup() {
         //Initialize parts
         try {
-            ms = new MoppySequencer();
+            ms = new MoppySequencer(rm);
             midiIn = new MoppyMIDIInput();
 
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(null, ex.toString());
         }
-        MoppyControlWindow mainWindow = new MoppyControlWindow(this);
+        mainWindow = new MoppyControlWindow(this);
         mainWindow.setStatus("Initializing...");
         mainWindow.setVisible(true);
         mainWindow.setStatus("Initialized.");
+        
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            public void run() { shutdownTasks(); }
+        }));
     }
 
+    //Things to do/cleanup before we close the application
+    private void shutdownTasks() {
+        mainWindow.currentInputPanel.shuttingDown();
+        rm.close();
+    }
+    
     /**
      * Main method launching the application.
      */

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyMIDIOutput.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyMIDIOutput.java
@@ -94,4 +94,10 @@ public class MoppyMIDIOutput implements MoppyReceiver{
             }
         }
     }
+    
+    //Nothing to do here
+    public void connecting() { }    
+    public void disconnecting() { }    
+    public void sequenceStarting() { }    
+    public void sequenceStopping() { }  
 }

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyPlayerOutput.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyPlayerOutput.java
@@ -54,8 +54,8 @@ public class MoppyPlayerOutput implements MoppyReceiver {
     }
 
     public void close() {
-            mb.resetDrives();
-            mb.close();
+        mb.resetDrives();
+        mb.close();
     }
 
     //Is called by Java MIDI libraries for each MIDI message encountered.
@@ -112,11 +112,10 @@ public class MoppyPlayerOutput implements MoppyReceiver {
 
     }
 
-    public void reset() {
-        mb.resetDrives();
-    }
-
-    public void silence() {
-        mb.silenceDrives();
-    }
+    public void reset() { mb.resetDrives(); }
+    public void silence() { mb.silenceDrives(); }    
+    public void connecting() { mb.sendEvent((byte) 100, (byte) 1, (byte) 0); }    
+    public void disconnecting() { mb.sendEvent((byte) 100, (byte) 2, (byte) 0); }    
+    public void sequenceStarting() { mb.sendEvent((byte) 100, (byte) 3, (byte) 0); }    
+    public void sequenceStopping() { mb.sendEvent((byte) 100, (byte) 4, (byte) 0); }  
 }

--- a/Java/MoppyDesk/src/moppydesk/outputs/MoppyReceiver.java
+++ b/Java/MoppyDesk/src/moppydesk/outputs/MoppyReceiver.java
@@ -14,4 +14,11 @@ public interface MoppyReceiver extends Receiver{
      */
     public void reset();
     public void silence();
+    
+    //MrSolidSnake745: Adding events to allow for defining appropriate responses per microcontroller
+    //These events will cause a specific set of system bytes to be sent on MoppyPlayerOutput, but can be useful for other things
+    public void connecting();
+    public void disconnecting();
+    public void sequenceStarting();
+    public void sequenceStopping();
 }

--- a/Java/MoppyDesk/src/moppydesk/ui/InputPanel.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/InputPanel.java
@@ -18,4 +18,7 @@ public abstract class InputPanel extends JPanel{
     //MrSolidSnake745: Below two optional methods define how preferences are saved/loaded for a given input panel    
     public void savePreferences() {}; //Called when connecting or switching panels on main window dropdown (MoppyControlWindow: , connect())
     public void loadPreferences() {}; //Called when main window class is instantiated (MoppyControlWindow: constructor)
+    //Another optional method to define how a panel handles the application shutting down
+    //  If you're going to override this method, either include savePreferenes(); or call the base method
+    public void shuttingDown() { savePreferences(); }; //Called when application is closing (MoppyUI) on the currently selected panel
 }

--- a/Java/MoppyDesk/src/moppydesk/ui/MoppyControlWindow.java
+++ b/Java/MoppyDesk/src/moppydesk/ui/MoppyControlWindow.java
@@ -33,7 +33,7 @@ public class MoppyControlWindow extends javax.swing.JFrame {
     SequencerControls seqControls;
     PlaylistControls playControls;
     
-    InputPanel currentInputPanel;
+    public InputPanel currentInputPanel;
 
     /**
      * Creates new form MoppyControlWindow
@@ -213,7 +213,8 @@ public class MoppyControlWindow extends javax.swing.JFrame {
             currentInputPanel.savePreferences();
             
             setStatus("Initializing Receivers...");
-            initializeReceivers();
+            initializeReceivers();                      
+            app.rm.connecting();
             
             //If pooling is enabled, send messages through pooler, otherwise bypass it
             inputSelectBox.setEnabled(false);
@@ -260,8 +261,7 @@ public class MoppyControlWindow extends javax.swing.JFrame {
     }
 
     private void initializeReceivers() throws NoSuchPortException, PortInUseException, UnsupportedCommOperationException, IOException, MidiUnavailableException {
-        app.rm.clearReceivers();
-        
+        app.rm.clearReceivers();        
         outputPlayers.clear();
         
         for (int ch = 1; ch <= 16; ch++) {
@@ -282,7 +282,7 @@ public class MoppyControlWindow extends javax.swing.JFrame {
                     app.rm.setReceiver(ch, outputPlayers.get(os.midiDeviceName));
                 }
             }
-        }
+        }                
     }
 
     private void updateInputPanel(){        


### PR DESCRIPTION
For my own purposes I needed a way to send certain "events" to connected microcontrollers. This set of changes accomplishes that. Feel free to change up my comments or code. I know many are not fond of my one-liner approach to coding and I understand that completely. I also know I tend to get over descriptive with comments sometimes.

Events added to MoppyReceiver:
- connecting
- disconnecting
- sequenceStarting
- sequenceStopping

Mainly used for sending specific system byte sequences on MoppyPlayerOutput. This allows me to execute various functions in response to those events. For instance on connecting/disconnecting, I have my microcontroller setup to respond by turning the main power supply for my setup on/off respectively. I've also used sequenceStarting/Stopping for turning an LED on and off to indicate a sequence is being played. On another version of Moppy I'm working on, this is also used to interrupt a standby process when a sequence is to be played.

Event added to InputPanel:
- shuttingDown

Simple event, all it does for now is cause the currently selected input panel to save preferences before exiting. However it will allow executing of any shutdown tasks that may be needed in the future. I have plans, but I don't want to go into detail about that yet. Still think it could possibly be useful for others.

Other features/additions:
- Added ability to enable/disable receivers (essentially channels) at the ReceiverMarshaller level
  - I mainly use this for automating my recording process, but I plan on using this for another input panel I'd like to build a little later on
- Added shutdown hook to close ReceiverMarshaller on application close
  - With the addition of the disconnecting event, this ensure disconnecting is called as the application exists as well as severs the connection between Moppy and the devices
